### PR TITLE
카메라 페이지 영상 축소 모드에서 카메라 영역 잘림 방지

### DIFF
--- a/ui/src/pages/camera/camera-page.js
+++ b/ui/src/pages/camera/camera-page.js
@@ -8,7 +8,8 @@ function toggleVideoSize(wrapper, button) {
     if (isExpanded) {
         // 축소
         wrapper.css({
-            'width': '320px',
+            'width': '100%',
+            'max-width': '320px',
             'position': 'relative'
         });
         wrapper.data('expanded', false);
@@ -18,6 +19,7 @@ function toggleVideoSize(wrapper, button) {
         // 확대
         wrapper.css({
             'width': '100%',
+            'max-width': 'none',
             'position': 'relative'
         });
         wrapper.data('expanded', true);
@@ -216,7 +218,8 @@ function displayCameras(cameras) {
         const videoCell = $('<td>');
         const videoWrapper = $('<div>').css({
             'position': 'relative',
-            'width': '320px',
+            'width': '100%',
+            'max-width': '320px',
             'background': '#000',
             'display': 'inline-block'
         });


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closes #41 

---

## ✍️ 진행한 작업
- 카메라 영역 잘림 max-width 설정으로 해결

---

## 💬 추가 코멘트
- 기타 전달할 내용 작성
